### PR TITLE
convert to python3 compatibility (uses six/futurize) and include option for md5 encrypted passwords.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 ## Description
 **htpasswd** is a library for working with htpasswd user (only basic authorization) and group files.
 
+supports both the crypt method and the MD5 encryption method.
+
 [![Build Status](https://secure.travis-ci.org/thesharp/htpasswd.png)](http://travis-ci.org/thesharp/htpasswd)
 
 ## Dependencies
@@ -32,6 +34,8 @@
             groupdb.delete_user("alice", "managers")
         except htpasswd.group.UserNotInAGroup, e:
             print e
+
+to encrypt with md5, just add mode='md5' to htpasswd.Basic(userdb, mode='md5')
 
 ## Provided methods
 
@@ -70,3 +74,6 @@ Raised by ``Group.add_user`` if user is already in a group.
 
 ### UserNotInAGroup
 Raised by ``Group.delete_user`` if user isn't in a group.
+
+### UnknownEncryptionMode
+raised by _encrypt_password if mode is not 'crypt' or 'md5'.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@
 
 supports both the crypt method and the MD5 encryption method.
 
+for the md5 method you *MUST* have openssl installed (and it must be in the system path.) does not use python openSSL bindings, but actually calls out to openssl.
+Not the best security method, feel free to fix for me.
+
 [![Build Status](https://secure.travis-ci.org/thesharp/htpasswd.png)](http://travis-ci.org/thesharp/htpasswd)
 
 ## Dependencies

--- a/htpasswd/basic.py
+++ b/htpasswd/basic.py
@@ -98,4 +98,4 @@ class Basic(object):
         return crypt(password, salt())
     def _md5_password(self, password):
         """uses openSSL to MD5 encrypt password."""
-        return subprocess.check_output(['openssl', 'passwd', '-apr1', password]).decode('utf-8')
+        return subprocess.check_output(['openssl', 'passwd', '-apr1', password]).decode('utf-8').strip()

--- a/htpasswd/group.py
+++ b/htpasswd/group.py
@@ -1,3 +1,4 @@
+from builtins import object
 import re
 from orderedmultidict import omdict
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 orderedmultidict>=0.7
+future

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -65,6 +65,10 @@ class BasicMD5Tests(unittest.TestCase):
         with htpasswd.Basic(t_userdb, mode='blah') as userdb:
             self.assertRaises(htpasswd.UnknownEncryptionMode, lambda: userdb.change_password("bob",
                                                                                      "password"))
+    def test_no_newline(self):
+        with htpasswd.Basic(t_userdb, mode='md5') as userdb:
+            self.assertNotIn('\n', userdb._encrypt_password('password'), msg="no newline characters allowed in pwd")
+            self.assertNotIn('\r', userdb._encrypt_password('password'), msg="no newline characters allowed in pwd")
     def test__crypt_password(self):
         with htpasswd.Basic(t_userdb, mode='md5') as userdb:
             password = userdb._crypt_password("password")

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -8,6 +8,69 @@ from crypt import crypt
 
 t_userdb = "tests/test.userdb"
 
+class BasicMD5Tests(unittest.TestCase):
+    def setUp(self):
+        shutil.copy(t_userdb, "tests/test.userdb_backup")
+
+    def tearDown(self):
+        shutil.move("tests/test.userdb_backup", t_userdb)
+
+    def test_users(self):
+        with htpasswd.Basic(t_userdb, mode='md5') as userdb:
+            self.assertEqual(userdb.users, ["bob", "alice"])
+
+    def test___contains__(self):
+        with htpasswd.Basic(t_userdb) as userdb:
+            self.assertTrue(userdb.__contains__("bob"))
+            self.assertFalse(userdb.__contains__("bob1"))
+
+    def test_not_exists(self):
+        with htpasswd.Basic(t_userdb, mode='md5') as userdb:
+            def not_exists():
+                userdb.__contains__("nobody")
+            self.assertRaises(UserNotExists, not_exists())
+
+    def test_exists(self):
+        with htpasswd.Basic(t_userdb, mode='md5') as userdb:
+            self.assertRaises(UserExists, lambda: userdb.add("bob", "password"))
+
+    def test_add(self):
+        with htpasswd.Basic(t_userdb, mode='md5') as userdb:
+            userdb.add("henry", "password")
+            self.assertTrue(userdb.__contains__("henry"))
+
+    def test_pop(self):
+        with htpasswd.Basic(t_userdb, mode='md5') as userdb:
+            userdb.pop("alice")
+            self.assertFalse(userdb.__contains__("alice"))
+
+    def test_pop_exception(self):
+        with htpasswd.Basic(t_userdb, mode='md5') as userdb:
+            self.assertRaises(htpasswd.UserNotExists, lambda: userdb.pop("nobody"))
+
+    def test_change_password(self):
+        with htpasswd.Basic(t_userdb, mode='md5') as userdb:
+            userdb.change_password("alice", "password")
+        with open(t_userdb, "r") as users:
+            for user in users.readlines():
+                if user.startswith("alice:"):
+                    test = user
+        self.assertRegexpMatches(test, "alice:\$apr1\$")
+
+    def test_change_password_exception(self):
+        with htpasswd.Basic(t_userdb, mode='md5') as userdb:
+            self.assertRaises(htpasswd.UserNotExists, lambda: userdb.change_password("nobody",
+                                                                                     "password"))
+    def test_invalid_mode_exception(self):
+        with htpasswd.Basic(t_userdb, mode='blah') as userdb:
+            self.assertRaises(htpasswd.UnknownEncryptionMode, lambda: userdb.change_password("bob",
+                                                                                     "password"))
+    def test__crypt_password(self):
+        with htpasswd.Basic(t_userdb, mode='md5') as userdb:
+            password = userdb._crypt_password("password")
+            salt = password[:2]
+            test = crypt("password", salt)
+            self.assertEqual(password, test)
 
 class BasicTests(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
HI! I needed md5 encrypted passwords for my use case, and so I added it to your library.
we also are in the process of moving our code to work across python2 and python3, so I fixed that up as well.

I probably should have made them 2 different pull requests, but I didn't think about it until after I was done, so you get them in bulk :) sorry.

