### PR TITLE
add bcrypt support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,5 @@ python:
     - "2.7"
     - "3.3"
     - "3.4"
-install: pip install .
+install: pip install .[bcrypt]
 script: nosetests

--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 # htpasswd [![Build Status](https://secure.travis-ci.org/thesharp/htpasswd.png)](http://travis-ci.org/thesharp/htpasswd)
 
 ## Description
-**htpasswd** is a library for working with htpasswd user (only basic authorization) and group files. It supports CRYPT, MD5 (based) and MD5 (apache variant, 'apr1') encryption methods. To actually use MD5 encryption method you *MUST* have an ``openssl`` binary installed into system ``$PATH``.
+**htpasswd** is a library for working with htpasswd user (only basic authorization) and group files. It supports CRYPT, BCRYPT, MD5 (based) and MD5 (apache variant, 'apr1') encryption methods. To actually use MD5 encryption method you *MUST* have an ``openssl`` binary installed into system ``$PATH``. For BCRYPT support it is required to install additional dependencies. Use `pip install htpasswd[bcrypt]` to do so.
 
 ## Dependencies
 - Python 2.7 or 3.3 or 3.4
 - [orderedmultidict](http://pypi.python.org/pypi/orderedmultidict/0.7) >= 0.7
 - [future](https://pypi.python.org/pypi/future)
+- [bcrypt](https://pypi.org/project/bcrypt/) (for bcrypt support)
 - [nose](http://pypi.python.org/pypi/nose/) >= 1.1.2 (for tests)
 
 ## Sample usage
@@ -39,6 +40,10 @@ To use MD5 apache variant encryption, add ``mode="md5"`` to the constructor:
 or use ``md5-base`` for MD5 based encryotion:
 
     with htpasswd.Basic("/path/to/user.db", mode="md5-base") as userdb
+
+or use ``bcrypt`` for BCRYPT based encryotion:
+
+with htpasswd.Basic("/path/to/user.db", mode="bcrypt") as userdb
 
 ## Provided methods
 
@@ -75,4 +80,4 @@ Raised by ``Group.add_user`` if user is already in a group.
 Raised by ``Group.delete_user`` if user isn't in a group.
 
 ### UnknownEncryptionMode
-Raised by _encrypt_password if mode is not 'crypt', 'md5' or 'md5-base'.
+Raised by _encrypt_password if mode is not 'crypt', 'bcrypt', 'md5' or 'md5-base'.

--- a/htpasswd/basic.py
+++ b/htpasswd/basic.py
@@ -2,6 +2,7 @@ from builtins import object
 from crypt import crypt
 from string import ascii_letters, digits
 from random import choice
+from importlib import import_module
 import subprocess
 try:
     from collections import OrderedDict
@@ -36,6 +37,8 @@ class Basic(object):
     It is passed the path to userdb file. """
 
     def __init__(self, userdb, mode="crypt"):
+        if mode == "bcrypt":
+            self.bcrypt = import_module("bcrypt")
         self.encryption_mode = mode
         self.userdb = userdb
         self.initial_users = OrderedDict()
@@ -93,6 +96,8 @@ class Basic(object):
             return self._md5_password(password)
         elif self.encryption_mode.lower() == 'md5-base':
             return self._md5_base_password(password)
+        elif self.encryption_mode.lower() == 'bcrypt':
+            return self._bcrypt_password(password)
         else:
             raise UnknownEncryptionMode(self.encryption_mode)
 
@@ -120,3 +125,8 @@ class Basic(object):
                                         'passwd',
                                         '-1',
                                         password]).decode('utf-8').strip()
+
+    def _bcrypt_password(self, password):
+        """ Crypts password using bcrypt encryption """
+
+        return self.bcrypt.hashpw(password.encode("utf-8"), self.bcrypt.gensalt()).decode("utf-8")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 orderedmultidict>=0.7
 future
+bcrypt>=3.1

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,9 @@ setup(
     version="2.3",
     packages=["htpasswd"],
     install_requires=requires,
+    extras_require={
+      'bcrypt': ["bcrypt"],
+    },
     author="Ilya Otyutskiy",
     author_email="ilya.otyutskiy@icloud.com",
     maintainer="Ilya Otyutskiy",

--- a/tests/test.userdb.bcrypt
+++ b/tests/test.userdb.bcrypt
@@ -1,0 +1,2 @@
+bob:$2y$12$fTMck2Ow8yiO0TuhXv2aY.4MVB.qqYm2.fOwrvTq9hnG8M/UlDVy.
+alice:$2y$12$vtDnpmrqHGOcBRTJal9njuK8F5Dc92GhczIBGViSotITb1caQO6dm

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -8,6 +8,7 @@ from crypt import crypt
 
 t_userdb = "tests/test.userdb"
 t_userdb_md5_base = "tests/test.userdb.md5base"
+t_userdb_bcrypt = "tests/test.userdb.bcrypt"
 
 
 class BasicMD5Tests(unittest.TestCase):
@@ -159,6 +160,81 @@ class BasicMD5BaseTests(unittest.TestCase):
 
     def test__crypt_password(self):
         with htpasswd.Basic(t_userdb, mode='md5') as userdb:
+            password = userdb._crypt_password("password")
+            salt = password[:2]
+            test = crypt("password", salt)
+            self.assertEqual(password, test)
+
+
+class BasicBcryptTests(unittest.TestCase):
+    def setUp(self):
+        shutil.copy(t_userdb_bcrypt, "tests/test.userdb_backup")
+
+    def tearDown(self):
+        shutil.move("tests/test.userdb_backup", t_userdb_bcrypt)
+
+    def test_users(self):
+        with htpasswd.Basic(t_userdb_bcrypt, mode='bcrypt') as userdb:
+            self.assertEqual(userdb.users, ["bob", "alice"])
+
+    def test___contains__(self):
+        with htpasswd.Basic(t_userdb_bcrypt) as userdb:
+            self.assertTrue(userdb.__contains__("bob"))
+            self.assertFalse(userdb.__contains__("bob1"))
+
+    def test_not_exists(self):
+        with htpasswd.Basic(t_userdb_bcrypt, mode='bcrypt') as userdb:
+            def not_exists():
+                userdb.__contains__("nobody")
+            self.assertRaises(UserNotExists, not_exists())
+
+    def test_exists(self):
+        with htpasswd.Basic(t_userdb_bcrypt, mode='bcrypt') as userdb:
+            self.assertRaises(UserExists, lambda: userdb.add("bob", "password"))
+
+    def test_add(self):
+        with htpasswd.Basic(t_userdb_bcrypt, mode='bcrypt') as userdb:
+            userdb.add("henry", "password")
+            self.assertTrue(userdb.__contains__("henry"))
+
+    def test_pop(self):
+        with htpasswd.Basic(t_userdb_bcrypt, mode='bcrypt') as userdb:
+            userdb.pop("alice")
+            self.assertFalse(userdb.__contains__("alice"))
+
+    def test_pop_exception(self):
+        with htpasswd.Basic(t_userdb_bcrypt, mode='bcrypt') as userdb:
+            self.assertRaises(htpasswd.UserNotExists,
+                              lambda: userdb.pop("nobody"))
+
+    def test_change_password(self):
+        with open(t_userdb_bcrypt, "r") as users:
+            for user in users.readlines():
+                if user.startswith("alice:"):
+                    old_passwd = user
+        with htpasswd.Basic(t_userdb_bcrypt, mode='bcrypt') as userdb:
+            userdb.change_password("alice", "password")
+        with open(t_userdb_bcrypt, "r") as users:
+            for user in users.readlines():
+                if user.startswith("alice:"):
+                    new_passwd = user
+        self.assertNotEqual(old_passwd, new_passwd)
+
+    def test_change_password_exception(self):
+        with htpasswd.Basic(t_userdb_bcrypt, mode='bcrypt') as userdb:
+            self.assertRaises(htpasswd.UserNotExists,
+                              lambda: userdb.change_password("nobody",
+                                                             "password"))
+
+    def test_no_newline(self):
+        with htpasswd.Basic(t_userdb_bcrypt, mode='bcrypt') as userdb:
+            self.assertNotIn('\n', userdb._encrypt_password('password'),
+                             msg="no newline characters allowed in pwd")
+            self.assertNotIn('\r', userdb._encrypt_password('password'),
+                             msg="no newline characters allowed in pwd")
+
+    def test__crypt_password(self):
+        with htpasswd.Basic(t_userdb_bcrypt, mode='bcrypt') as userdb:
             password = userdb._crypt_password("password")
             salt = password[:2]
             test = crypt("password", salt)


### PR DESCRIPTION
bcrypt is also supported by the [htpasswd](https://httpd.apache.org/docs/2.4/programs/htpasswd.html) command of the Apache HTTP server project and considered very save.