### PR TITLE
change import crypt for windows compatibility

### DIFF
--- a/htpasswd/basic.py
+++ b/htpasswd/basic.py
@@ -1,5 +1,4 @@
 from builtins import object
-from crypt import crypt
 from string import ascii_letters, digits
 from random import choice
 import subprocess
@@ -98,7 +97,8 @@ class Basic(object):
 
     def _crypt_password(self, password):
         """ Crypts password """
-
+        from crypt import crypt
+        
         def salt():
             """ Generates some salt """
             symbols = ascii_letters + digits


### PR DESCRIPTION
Importing crypt up-front causes an incompatibility with Windows as it is UNIX only, however users can still use md5

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/thesharp/htpasswd/10)
<!-- Reviewable:end -->
